### PR TITLE
fix: dependending repo's name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ LDFLAGS=-ldflags "-X main.VersionNum=${VERSION} -X main.Build=${BUILD} -X main.B
 .DEFAULT_GOAL: $(BINARY)
 
 $(BINARY): $(SOURCES)
-	go get github.com/mholt/caddy/caddyhttp
+	go get github.com/caddyserver/caddy/caddyhttp
 	go get github.com/BurntSushi/toml
-	go get github.com/mholt/caddy
-	go get github.com/mholt/caddy/caddytls
+	go get github.com/caddyserver/caddy
+	go get github.com/caddyserver/caddy/caddytls
 	go get github.com/toqueteos/webbrowser
 	go get github.com/bobertlo/go-id3/id3
 	go get github.com/tcolgate/mp3

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **Update 08/09/2016: Version 1.5 released!**
 
-- Updated to the latest version of [caddy](https://github.com/mholt/caddy)
+- Updated to the latest version of [caddy](https://github.com/caddyserver/caddy)
 - Updated to latest version of [howler.js](https://github.com/goldfire/howler.js/)
 
 --------------------------------------------------------------------------------
@@ -104,7 +104,7 @@ xinit /usr/bin/luakit -u http://W.X.Y.Z:5000
 - Zach Simpson for [his paper on simple clock synchronization](http://www.mine-control.com/zack/timesync/timesync.html)
 - Everyone on the [/r/raspberry_pi](https://www.reddit.com/r/raspberry_pi/comments/3xc8kq/simple_python_script_to_allow_multiple_raspberry/) and [/r/python](https://www.reddit.com/r/Python/comments/3xc8mj/simple_python_script_to_allow_multiple_computers/) threads for great feature requests and bug reports!
 - [ClkerFreeVectorImages](https://pixabay.com/en/users/ClkerFreeVectorImages-3736/) and [OpenClipartVectors](https://pixabay.com/en/users/OpenClipartVectors-30363/) for the Public Domain vectors
-- [mholt](github.com/mholt) for the invaluable `Caddy`
+- [caddyserver](github.com/caddyserver) for the invaluable `Caddy`
 - [tcolgate](http://github.com/tcolgate) for the `mp3` package
 - [bobertlo](http://github.com/bobertlo) for the `go-id3` package
 - [BurntSushi](http://github.com/BurntSushi) for their `toml` library

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you don't want to install _anything_, just download the [compiled version](ht
 git clone https://github.com/schollz/musicsaur.git
 cd musicsaur
 go get ./...
-go build
+GO111MODULE=on go build
 ```
 
 Then copy the configuration file

--- a/config.cfg
+++ b/config.cfg
@@ -1,0 +1,51 @@
+###################################################################
+#REQUIRED: ENTER YOUR MUSIC FOLDERS
+###################################################################
+
+MusicFolders = ['demo']
+
+###################################################################
+# OPTIONAL: SERVER PARAMETERS
+# Random:               random playback
+# Ffmpeg:               allows ffmpeg (will skip if not available)
+#####################################################################
+
+[Server]
+Random = false
+Ffmpeg = false
+
+#######################################################################
+# OPTIONAL: CLIENT PARAMETERS
+# CheckupWaitTime: 	the wait time in between polls in milliseconds
+# MaxSyncLag: 		  minimum acceptable lag between server and
+#					          client in milliseconds
+######################################################################
+
+[Client]
+CheckupWaitTime = 500
+MaxSyncLag = 30
+
+#########################################################################
+# OPTIONAL: REMOTE CLIENT CONFIGURATION
+# Useful for automatically starting Raspberry Pis, uncomment and
+# add as many as you want
+# You can use Key or use a Password
+# (the key searches in home directory first)
+# luakit and midori are great to get started with on Pis
+##########################################################################
+
+[Autostart]
+
+#	[Autostart.1]
+#	User = 'user'
+#	Server = 'someserver.org'
+#	Key = '/.ssh/id_rsa'
+#	Port = '22'
+#	RemoteBrowser = '/usr/bin/midori'
+
+#	[Autostart.2]
+#	User = 'pi'
+#	Server = '192.168.1.5'
+#	Password = 'yourpassword'
+#	Port = '22'
+#	RemoteBrowser = '/usr/bin/luakit'

--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/mp3s.go
+++ b/mp3s.go
@@ -95,7 +95,9 @@ func getMp3Length(path string) (totalTime int64) {
 	totalTime = 0
 	for {
 
-		if err := d.Decode(&f); err != nil {
+		skippedBytes := 0
+
+		if err := d.Decode(&f, &skippedBytes); err != nil {
 			//fmt.Println(err)
 			return
 		}

--- a/server.go
+++ b/server.go
@@ -16,12 +16,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 	"github.com/toqueteos/webbrowser"
 	"gopkg.in/tylerb/graceful.v1"
 	// plug in the HTTP server type
-	_ "github.com/mholt/caddy/caddyhttp"
-	"github.com/mholt/caddy/caddytls"
+	_ "github.com/caddyserver/caddy/caddyhttp"
 )
 
 const (
@@ -219,7 +218,6 @@ Options:`)
 	caddy.AppVersion = VersionNum + " (" + Build + ")"
 	caddy.Quiet = true
 	caddy.PidFile = ""
-	caddytls.DefaultCAUrl = "https://acme-v01.api.letsencrypt.org/directory"
 
 	caddyfile, err := loadCaddyfile()
 	if err != nil {


### PR DESCRIPTION
It seems that they have transferred the repo `caddy` from `mholt` to `caddyserver`.
So, here is the fix.